### PR TITLE
feat: add CLI

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,8 +43,12 @@ setup(
     url="https://github.com/tiiuae/onebitllms",
     package_dir={"": "src"},
     packages=find_packages("src"),
-    entry_points={},
     python_requires=">=3.9.0",
+    entry_points={
+        'console_scripts': [
+            'onebitllms = onebitllms.cli:main',
+        ],
+    },
     install_requires=[
         "torch",
         "transformers>=4.51.0",

--- a/src/onebitllms/cli/__init__.py
+++ b/src/onebitllms/cli/__init__.py
@@ -1,0 +1,14 @@
+# Copyright 2026 Falcon-LLM Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from .main import main

--- a/src/onebitllms/cli/main.py
+++ b/src/onebitllms/cli/main.py
@@ -32,8 +32,6 @@ def main():
     command_function = CLI_CMD_MAPPING[command_name]
     print(f"Executing: {command_function}")
     command_function(*sys.argv[2:])
-    # print(command_name)
-
 
 
 

--- a/src/onebitllms/cli/main.py
+++ b/src/onebitllms/cli/main.py
@@ -1,0 +1,41 @@
+# Copyright 2026 Falcon-LLM Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import sys
+from argparse import ArgumentParser
+
+from ..utils import quantize_to_1bit, convert_to_bf16
+
+CLI_CMD_MAPPING = {
+    'convert': quantize_to_1bit,
+    'convert_in_bf16': convert_to_bf16,
+}
+
+def main():
+    if len(sys.argv) == 1:
+        raise ValueError(f"You need to specify a command from: {CLI_CMD_MAPPING.keys()}, e.g.: `onebitllms convert` ")
+    command_name = sys.argv[1]
+
+    if command_name not in CLI_CMD_MAPPING:
+        raise ValueError(f"Invalid command name. Supported command names are: {CLI_CMD_MAPPING.keys()}")
+    
+    command_function = CLI_CMD_MAPPING[command_name]
+    print(f"Executing: {command_function}")
+    command_function(*sys.argv[2:])
+    # print(command_name)
+
+
+
+
+
+


### PR DESCRIPTION
This PR adds a very minimalistic CLI to `onebitllms` to easily convert models to bitnet format instead of using custom python scripts. E.g.:

```
onebitllms quantize_to_1bit INPUT_PATH OUTPUT_PATH
```

Or:

```
onebitllms convert_to_bf16 INPUT_PATH OUTPUT_PATH
```

