### PR TITLE
Fix examples/sft.py crash: --torch_dtype renamed to --dtype in TRL

### DIFF
--- a/examples/sft.py
+++ b/examples/sft.py
@@ -17,7 +17,7 @@
 python examples/sft.py \
     --model_name_or_path tiiuae/Falcon-E-1B-Base \
     --model_revision prequantized \
-    --torch_dtype bfloat16 \
+    --dtype bfloat16 \
     --learning_rate 0.0001 \
     --dataset_name trl-lib/Capybara \
     --per_device_train_batch_size 1 \
@@ -57,7 +57,7 @@ def main(script_args, training_args, model_args):
         revision=model_args.model_revision,
         trust_remote_code=model_args.trust_remote_code,
         attn_implementation=model_args.attn_implementation,
-        torch_dtype=model_args.torch_dtype,
+        torch_dtype=model_args.dtype,
         use_cache=False if training_args.gradient_checkpointing else True,
         device_map=get_kbit_device_map() if quantization_config is not None else None,
         quantization_config=quantization_config,


### PR DESCRIPTION
## Summary

Fixes #10.

Running the SFT example crashes immediately at argument parsing:

```
ValueError: Some specified arguments are not used by the HfArgumentParser: ['--torch_dtype', 'bfloat16']
```

TRL renamed `ModelConfig.torch_dtype` to `dtype` (following the `transformers` deprecation of `torch_dtype`), so `--torch_dtype` is no longer a recognized CLI argument for `TrlParser((ScriptArguments, SFTConfig, ModelConfig))`.

## Changes

- `examples/sft.py`: use `--dtype bfloat16` in the example command, and read `model_args.dtype`. The value is still passed as the `from_pretrained` `torch_dtype=` kwarg, which `transformers >= 4.51` (the pinned minimum) continues to accept, so this stays compatible across the supported range.

## Verification

Reproduced the exact failure and the fix against the current TRL (1.10.0):

```
--torch_dtype bfloat16 -> ValueError: Some specified arguments are not used ... ['--torch_dtype', ...]
--dtype bfloat16       -> parsed OK; model_args.dtype = bfloat16
```
